### PR TITLE
COPY works now without OF (in most cases)

### DIFF
--- a/Canal/MainWindow.cs
+++ b/Canal/MainWindow.cs
@@ -3,6 +3,7 @@ using Model.File;
 using System.Diagnostics;
 using System.Net;
 using Util;
+using Util.Events;
 
 namespace Canal
 {
@@ -19,6 +20,8 @@ namespace Canal
         private readonly TabUtil _tabUtil;
 
         private readonly string[] _openFilesOnStartup;
+
+        
 
         public MainWindow(string[] files = null)
         {
@@ -38,7 +41,11 @@ namespace Canal
             UpdateMenuItems(null, null);
 
             LoadMostRecentDirectory();
+            
+            TextUtil.Instance.ErrorEventHandler+=(sender, s) => MessageBox.Show(s, Resources.Error, MessageBoxButtons.OK);
         }
+
+        
 
         private void LoadMostRecentDirectory()
         {

--- a/Model/Exceptions/CopiedRessourceNotFoundException.cs
+++ b/Model/Exceptions/CopiedRessourceNotFoundException.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Model.Exceptions
+{
+    public class CopiedRessourceNotFoundException : Exception
+    {
+        public string Filename { get; set; }
+
+        public CopiedRessourceNotFoundException(string filename) : base("The file " + filename + " has no occurs in the file cache and could therefore not be linked!")
+        {
+            Filename = filename;
+        }
+    }
+}

--- a/Model/Exceptions/CopiedRessourceNotFoundException.cs
+++ b/Model/Exceptions/CopiedRessourceNotFoundException.cs
@@ -2,11 +2,11 @@
 
 namespace Model.Exceptions
 {
-    public class CopiedRessourceNotFoundException : Exception
+    public class CopiedRessourceNotFoundException : CanalException
     {
         public string Filename { get; set; }
 
-        public CopiedRessourceNotFoundException(string filename) : base("The file " + filename + " has no occurs in the file cache and could therefore not be linked!")
+        public CopiedRessourceNotFoundException(string filename) : base("The file " + filename + " could not be found.")
         {
             Filename = filename;
         }

--- a/Model/Exceptions/CopiedRessourceNotIdentifiedDistinctlyByNameException.cs
+++ b/Model/Exceptions/CopiedRessourceNotIdentifiedDistinctlyByNameException.cs
@@ -2,11 +2,11 @@
 
 namespace Model.Exceptions
 {
-    public class CopiedRessourceNotIdentifiedDistinctlyByNameException : Exception
+    public class CopiedRessourceNotIdentifiedDistinctlyByNameException : CanalException
     {
         public string Filename { get; set; }
 
-        public CopiedRessourceNotIdentifiedDistinctlyByNameException(string filename) : base("The file " + filename + " occurs mutliple times in the file cache and could therefore not be linked!")
+        public CopiedRessourceNotIdentifiedDistinctlyByNameException(string filename) : base("The file " + filename + " occurs mutliple times in the file cache and could therefore not be linked.")
         {
             Filename = filename;
         }

--- a/Model/Exceptions/CopiedRessourceNotIdentifiedDistinctlyByNameException.cs
+++ b/Model/Exceptions/CopiedRessourceNotIdentifiedDistinctlyByNameException.cs
@@ -4,8 +4,11 @@ namespace Model.Exceptions
 {
     public class CopiedRessourceNotIdentifiedDistinctlyByNameException : Exception
     {
+        public string Filename { get; set; }
+
         public CopiedRessourceNotIdentifiedDistinctlyByNameException(string filename) : base("The file " + filename + " occurs mutliple times in the file cache and could therefore not be linked!")
         {
+            Filename = filename;
         }
     }
 }

--- a/Model/Exceptions/CopiedRessourceNotIdentifiedDistinctlyByNameException.cs
+++ b/Model/Exceptions/CopiedRessourceNotIdentifiedDistinctlyByNameException.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Model.Exceptions
+{
+    public class CopiedRessourceNotIdentifiedDistinctlyByNameException : Exception
+    {
+        public CopiedRessourceNotIdentifiedDistinctlyByNameException(string filename) : base("The file " + filename + " occurs mutliple times in the file cache and could therefore not be linked!")
+        {
+        }
+    }
+}

--- a/Model/Model.csproj
+++ b/Model/Model.csproj
@@ -39,6 +39,7 @@
   <ItemGroup>
     <Compile Include="Exceptions\CanalException.cs" />
     <Compile Include="Exceptions\CopiedRessourceNotIdentifiedDistinctlyByNameException.cs" />
+    <Compile Include="Exceptions\CopiedRessourceNotFoundException.cs" />
     <Compile Include="Exceptions\MultipleOccursException.cs" />
     <Compile Include="Exceptions\RecursionTooDeepException.cs" />
     <Compile Include="Exceptions\RedefinedVariableNotFoundException.cs" />

--- a/Model/Model.csproj
+++ b/Model/Model.csproj
@@ -38,6 +38,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Exceptions\CanalException.cs" />
+    <Compile Include="Exceptions\CopiedRessourceNotIdentifiedDistinctlyByNameException.cs" />
     <Compile Include="Exceptions\MultipleOccursException.cs" />
     <Compile Include="Exceptions\RecursionTooDeepException.cs" />
     <Compile Include="Exceptions\RedefinedVariableNotFoundException.cs" />

--- a/Util/Constants.cs
+++ b/Util/Constants.cs
@@ -37,6 +37,8 @@ namespace Util
 
         public static readonly string Copy = @" *COPY (?<program>[\w]+) +OF +(?<folder>[\w]+)\.";
 
+        public static readonly string CopyWithoutFolder = @" *COPY (?<program>[\w]+)\.";
+
         private static readonly string VarLevel = @"^[ ]+(?<level>\d\d)";
 
         private static readonly string VarRedefines = @"(REDEFINES *(?<redefines>[\w\d-()]+))?";

--- a/Util/FileUtil.cs
+++ b/Util/FileUtil.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
+using Model.Exceptions;
 using Util.Events;
 using Util.Properties;
 
@@ -103,6 +104,25 @@ namespace Util
                 return null;
 
             return _files.AsParallel().Where(file => file.Key.Contains(programName + ".") && file.Key.Contains(folderName)).Select(file => file.Value).First();
+        }
+
+        public FileReference GetFileReferenceWithoutKnownFolderName(string programName)
+        {
+            if (string.IsNullOrWhiteSpace(programName))
+                return null;
+
+
+            
+            ParallelQuery<FileReference> allFileReferencesWithGivenName =  _files.AsParallel().Where(file => file.Key.Contains(programName + ".")).Select(file => file.Value);
+            if (allFileReferencesWithGivenName.Count() > 1)
+            {
+                //exception
+                throw new CopiedRessourceNotIdentifiedDistinctlyByNameException(programName);
+            }
+            else
+            {
+                return allFileReferencesWithGivenName.First();
+            }
         }
 
         /// <summary>

--- a/Util/FileUtil.cs
+++ b/Util/FileUtil.cs
@@ -106,21 +106,38 @@ namespace Util
             return _files.AsParallel().Where(file => file.Key.Contains(programName + ".") && file.Key.Contains(folderName)).Select(file => file.Value).First();
         }
 
+        /// <summary>
+        /// Method to find file references (more specific in the using context of this method: file references to copybooks) without a given parent folder.
+        /// Because there is no distinct location given, the selection of the file reference is based on a searching pattern:
+        /// If there is only one file with the given name in the cache, it's selected. If there are more than one, it's checked if only one of them ends
+        /// with the extension *.cbl. If that is true, this file reference is selected, if not an exception is thrown. This method could also search directly
+        /// for the filename + extension but that would cut out the possibility of loading files with functionally not correct extension like *.txt (in case their
+        /// name is unique).
+        /// </summary>
+        /// <param name="programName">The name of the program the file reference is wanted for.</param>
+        /// <returns>The file reference for the program.</returns>
         public FileReference GetFileReferenceWithoutKnownFolderName(string programName)
         {
             if (string.IsNullOrWhiteSpace(programName))
                 return null;
 
 
-            
+            //Selecting all files with the programName in the file cache ignoring the file extension.
             ParallelQuery<FileReference> allFileReferencesWithGivenName =  _files.AsParallel().Where(file => file.Key.Contains(programName + ".")).Select(file => file.Value);
+
+            //If more than one file of that name is found, a more specific search is done, icluding the file extension.
+            if (allFileReferencesWithGivenName.Count()>1)
+                allFileReferencesWithGivenName = _files.AsParallel().Where(file => file.Key.Contains(programName + ".cbl")).Select(file => file.Value);
+
+            
             if (allFileReferencesWithGivenName.Count() > 1)
             {
-                //exception
+                //If there is still more than one file, an exception is thrown, stating the fact, that a distinct file selection is impossible.
                 throw new CopiedRessourceNotIdentifiedDistinctlyByNameException(programName);
             }
             else
             {
+                //Else the found reference is returned.
                 return allFileReferencesWithGivenName.First();
             }
         }

--- a/Util/FileUtil.cs
+++ b/Util/FileUtil.cs
@@ -126,19 +126,15 @@ namespace Util
             var allFileReferencesWithGivenName =  _files.AsParallel().Where(file => file.Key.Contains(programName + ".")).Select(file => file.Value).ToList();
 
 
-            if (!allFileReferencesWithGivenName.Any())
+            if (allFileReferencesWithGivenName.None())
                 //No file found, also no chance of finding it using the more precise filters below
                 throw new CopiedRessourceNotFoundException(programName);
             else if (allFileReferencesWithGivenName.Count() > 1)
             {
                 //If more than one file of that name is found, a more specific search is done, including the file extension.
                 allFileReferencesWithGivenName =
-                    _files.AsParallel()
-                        .Where(file => file.Key.Contains(programName + ".cbl"))
-                        .Select(file => file.Value)
-                        .ToList();
-
-
+                    (from file in allFileReferencesWithGivenName where file.FilePath.EndsWith(".cbl") select file).ToList();
+                    
                 if (allFileReferencesWithGivenName.Count() != 1)
                     //If there is still more than one file (or no file now), an exception is thrown, stating the fact, that a distinct file selection is impossible.
                     throw new CopiedRessourceNotIdentifiedDistinctlyByNameException(programName);
@@ -146,7 +142,6 @@ namespace Util
 
             //Else the found reference is returned.
             return allFileReferencesWithGivenName.First();
-            
         }
 
         /// <summary>

--- a/Util/TextUtil.cs
+++ b/Util/TextUtil.cs
@@ -82,7 +82,13 @@ namespace Util
                     //Handling not distincly selectable files
                     Logger.Error(e.Message);
                     notCopyableCnt++;
-                    notCopyableNames += "\n" + e.Filename;
+                    notCopyableNames += "\n" + e.Filename + " (multiple occurences in related folders)";
+                }
+                catch (CopiedRessourceNotFoundException e)
+                {
+                    Logger.Error(e.Message);
+                    notCopyableCnt++;
+                    notCopyableNames += "\n" + e.Filename + " (no occurences in related folders)";
                 }
             }
 
@@ -91,8 +97,10 @@ namespace Util
             {
                 Logger.Warning("{0} of the {1} found COPYs could not be copied due to multiple occurences in the file system.",
                     notCopyableCnt, references.Count);
-                ErrorEventHandler(this, notCopyableCnt + " of the " + references.Count + " found COPYs could not be copied due to multiple occurences in the file system. " +
-                    "Please try to specify their parent folders in your Cobol code using\n\"COPY Filename OF Directory\" instead of just\n\"COPY Filename\" and then re-run the analysis.\n\nAffected file(s):" + notCopyableNames);
+                ErrorEventHandler(this, notCopyableCnt + " of the " + references.Count + " found COPYs could not be copied due to multiple or no occurences in the file system. " +
+                    "To fix multiple occurences please try to specify their parent folders in your Cobol code using\n\"COPY Filename OF Directory\" instead of just\n\"COPY Filename\" and then re-run the analysis.\n"+
+                    "To fix no occurenecs please make sure the file is available in the related folders."+
+                    "\n\nAffected file(s):" + notCopyableNames);
             }
 
             return references;


### PR DESCRIPTION
Including copybooks needed the Cobol source "COPY Name OF Folder", now "COPY Name" also works as long as the file Name is the only file with that name in the workspace or at least the only file named Name.cbl.
