### PR TITLE
Show file extensions toggle

### DIFF
--- a/Canal/UserControls/FilesView.Designer.cs
+++ b/Canal/UserControls/FilesView.Designer.cs
@@ -37,6 +37,7 @@
             this.showFileTypes_txt = new System.Windows.Forms.ToolStripMenuItem();
             this.showFileTypes_src = new System.Windows.Forms.ToolStripMenuItem();
             this.showFileTypes_custom = new System.Windows.Forms.ToolStripTextBox();
+            this.showFileExtensions = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.CollapseAllToolStripButton = new System.Windows.Forms.ToolStripButton();
             this.ExpandAllToolStripButton = new System.Windows.Forms.ToolStripButton();
@@ -76,7 +77,9 @@
             this.showFileTypes_cbl,
             this.showFileTypes_txt,
             this.showFileTypes_src,
-            this.showFileTypes_custom});
+            this.showFileTypes_custom,
+            this.toolStripSeparator1,
+            this.showFileExtensions});
             this.fileTypeDropDownButton.Image = ((System.Drawing.Image)(resources.GetObject("fileTypeDropDownButton.Image")));
             this.fileTypeDropDownButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.fileTypeDropDownButton.Name = "fileTypeDropDownButton";
@@ -123,6 +126,14 @@
             // 
             this.showFileTypes_custom.Name = "showFileTypes_custom";
             this.showFileTypes_custom.Size = new System.Drawing.Size(100, 23);
+            // 
+            // showFileTypes_src
+            // 
+            this.showFileExtensions.CheckOnClick = true;
+            this.showFileExtensions.Name = "showFileExtensions";
+            this.showFileExtensions.Size = new System.Drawing.Size(160, 22);
+            this.showFileExtensions.Text = "Show file extensions";
+            this.showFileExtensions.Click += new System.EventHandler(this.FileTypeClicked);
             // 
             // toolStripSeparator1
             // 
@@ -184,6 +195,7 @@
         private System.Windows.Forms.ToolStripMenuItem showFileTypes_txt;
         private System.Windows.Forms.ToolStripMenuItem showFileTypes_src;
         private System.Windows.Forms.ToolStripTextBox showFileTypes_custom;
+        private System.Windows.Forms.ToolStripMenuItem showFileExtensions;
         private System.Windows.Forms.TreeView filesTreeView;
         private System.Windows.Forms.ToolStripButton CollapseAllToolStripButton;
         private System.Windows.Forms.ToolStripButton ExpandAllToolStripButton;

--- a/Canal/UserControls/FilesView.cs
+++ b/Canal/UserControls/FilesView.cs
@@ -125,6 +125,7 @@ namespace Canal.UserControls
             Util.Properties.Settings.Default.FileTypeTxt = showFileTypes_txt.Checked;
             Util.Properties.Settings.Default.FileTypeSrc = showFileTypes_src.Checked;
             Util.Properties.Settings.Default.FileTypeCustom = showFileTypes_custom.Text;
+            Util.Properties.Settings.Default.ShowFileExtensions = showFileExtensions.Checked;
             Util.Properties.Settings.Default.Save();
         }
 
@@ -138,6 +139,8 @@ namespace Canal.UserControls
             showFileTypes_txt.Checked = Util.Properties.Settings.Default.FileTypeTxt;
             showFileTypes_src.Checked = Util.Properties.Settings.Default.FileTypeSrc;
             showFileTypes_custom.Text = Util.Properties.Settings.Default.FileTypeCustom;
+            showFileExtensions.Checked = Util.Properties.Settings.Default.ShowFileExtensions;
+
         }
 
         #endregion

--- a/Model/References/FileReference.cs
+++ b/Model/References/FileReference.cs
@@ -13,6 +13,7 @@ namespace Model.References
         {
             ReferencedIn = new List<Procedure>();
             FilePath = fileSystemEntry;
+            FileExtension = Path.GetExtension(fileSystemEntry);
             ProgramName = Path.GetFileNameWithoutExtension(fileSystemEntry);
             var folder = Path.GetDirectoryName(fileSystemEntry);
             if (folder != null)
@@ -24,6 +25,12 @@ namespace Model.References
         /// </summary>
         [DataMember]
         public string ProgramName { get; private set; }
+
+        /// <summary>
+        /// The extension
+        /// </summary>
+        [DataMember]
+        public string FileExtension { get; private set; }
 
         /// <summary>
         /// Name of leaf-directory

--- a/Util/FileUtil.cs
+++ b/Util/FileUtil.cs
@@ -232,13 +232,16 @@ namespace Util
         {
             _allowedEndings = new List<string>();
             if (Settings.Default.FileTypeCob)
-                _allowedEndings.AddRange(new List<string> { ".cob", ".cbl" });
+                _allowedEndings.Add(".cob");
+            if (Settings.Default.FileTypeCbl)
+                _allowedEndings.Add(".cbl");
             if (Settings.Default.FileTypeTxt)
                 _allowedEndings.Add(".txt");
             if (Settings.Default.FileTypeCob)
                 _allowedEndings.Add(".src");
             if (!string.IsNullOrWhiteSpace(Settings.Default.FileTypeCustom)) _allowedEndings.Add(Settings.Default.FileTypeCustom);
         }
+
 
         public void ReduceDirectoriesToAllowedFiles()
         {

--- a/Util/FileUtil.cs
+++ b/Util/FileUtil.cs
@@ -34,6 +34,8 @@ namespace Util
 
         private List<string> _allowedEndings = new List<string>();
 
+        private bool _showFileExtensions;
+
         /// <summary>
         /// Loads the given file. Uses internal cache for file contents.
         /// </summary>
@@ -228,7 +230,7 @@ namespace Util
             return foundFiles;
         }
 
-        private void UpdateAllowedEndings()
+        private void UpdateAllowedAndVisibleEndings()
         {
             _allowedEndings = new List<string>();
             if (Settings.Default.FileTypeCob)
@@ -240,6 +242,8 @@ namespace Util
             if (Settings.Default.FileTypeCob)
                 _allowedEndings.Add(".src");
             if (!string.IsNullOrWhiteSpace(Settings.Default.FileTypeCustom)) _allowedEndings.Add(Settings.Default.FileTypeCustom);
+
+            _showFileExtensions = Settings.Default.ShowFileExtensions;
         }
 
 
@@ -247,7 +251,7 @@ namespace Util
         {
             _directoriesWithAllowedFiles = new ConcurrentDictionary<string, List<FileReference>>();
 
-            UpdateAllowedEndings();
+            UpdateAllowedAndVisibleEndings();
 
             foreach (var dir in _directoriesAndFiles.Keys.AsParallel())
             {
@@ -259,7 +263,7 @@ namespace Util
 
         public int CountValidFiles(string dir)
         {
-            UpdateAllowedEndings();
+            UpdateAllowedAndVisibleEndings();
 
             AnalyzeFolder(dir);
 
@@ -283,7 +287,7 @@ namespace Util
             {
                 var foundFiles = _directoriesWithAllowedFiles[dir]
                     .Where(file => CultureInfo.CurrentCulture.CompareInfo.IndexOf(file.ProgramName, query, CompareOptions.IgnoreCase) >= 0)
-                    .Select(file => new TreeNode(file.ProgramName) { Tag = file }).ToArray();
+                    .Select(file => new TreeNode(_showFileExtensions ? file.ProgramName + file.FileExtension : file.ProgramName) { Tag = file }).ToArray();
 
                 if (foundFiles.Any())
                     result.Add(new TreeNode(dir, foundFiles));

--- a/Util/Properties/Settings.Designer.cs
+++ b/Util/Properties/Settings.Designer.cs
@@ -34,22 +34,7 @@ namespace Util.Properties {
                 this["FileTypeCob"] = value;
             }
         }
-
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("True")]
-        public bool FileTypeCbl
-        {
-            get
-            {
-                return ((bool)(this["FileTypeCbl"]));
-            }
-            set
-            {
-                this["FileTypeCbl"] = value;
-            }
-        }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
@@ -106,6 +91,30 @@ namespace Util.Properties {
             }
             set {
                 this["TocSort"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool ShowFileExtensions {
+            get {
+                return ((bool)(this["ShowFileExtensions"]));
+            }
+            set {
+                this["ShowFileExtensions"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool FileTypeCbl {
+            get {
+                return ((bool)(this["FileTypeCbl"]));
+            }
+            set {
+                this["FileTypeCbl"] = value;
             }
         }
     }

--- a/Util/Properties/Settings.settings
+++ b/Util/Properties/Settings.settings
@@ -20,5 +20,11 @@
     <Setting Name="TocSort" Type="Util.SortKind" Scope="User">
       <Value Profile="(Default)">Alphabetical</Value>
     </Setting>
+    <Setting Name="ShowFileExtensions" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
+    <Setting Name="FileTypeCbl" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Util/app.config
+++ b/Util/app.config
@@ -22,6 +22,12 @@
             <setting name="TocSort" serializeAs="String">
                 <value>Alphabetical</value>
             </setting>
+            <setting name="ShowFileExtensions" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="FileTypeCbl" serializeAs="String">
+                <value>True</value>
+            </setting>
         </Util.Properties.Settings>
     </userSettings>
 </configuration>


### PR DESCRIPTION
Bei den ganzen Mergeschwierigkeiten ist ein Teil des letzten Branches (Fehler im aktuellen Stand: Anzeige von Dateiendungen kann nicht getoggelt werden, *.col und *.cbl-Filter funktionieren nicht richtig) nicht mit reingekommen, ich hab das nochmal manuell rübergezogen.