### PR TITLE
Fixed the problem that it was not possible to Strg+C a variable insta…

### DIFF
--- a/Canal/UserControls/FileControl.cs
+++ b/Canal/UserControls/FileControl.cs
@@ -244,7 +244,8 @@ namespace Canal.UserControls
             {
                 VariableInfo variableInfoControl = new VariableInfo(CobolFile.Variables[word], this) { Dock = DockStyle.Fill };
                 splitContainerRight.Panel2.Controls.Add(variableInfoControl);
-                
+                variableInfoControl.ScrollToSelectedVariable();
+
                 if (findInCode)
                     codeBox.FindNext(word, false, false, true, true);
                 return;

--- a/Canal/UserControls/FileControl.cs
+++ b/Canal/UserControls/FileControl.cs
@@ -244,11 +244,7 @@ namespace Canal.UserControls
             {
                 VariableInfo variableInfoControl = new VariableInfo(CobolFile.Variables[word], this) { Dock = DockStyle.Fill };
                 splitContainerRight.Panel2.Controls.Add(variableInfoControl);
-
-                //Giving focus to the control so the double clicked variable stays highlighted.
-                variableInfoControl.Focus();
-                variableInfoControl.ScrollToSelectedVariable();
-
+                
                 if (findInCode)
                     codeBox.FindNext(word, false, false, true, true);
                 return;

--- a/Canal/UserControls/WordInfoViews/VariableInfo.cs
+++ b/Canal/UserControls/WordInfoViews/VariableInfo.cs
@@ -25,6 +25,10 @@ namespace Canal.UserControls.WordInfoViews
             };
         }
 
+        public void ScrollToSelectedVariable()
+        {
+            VariableInfoTreeView.ScrollToSelectedNode();
+        }
 
 
         private TreeNode FillVariableTreeView(Variable variable)

--- a/Canal/UserControls/WordInfoViews/VariableInfo.cs
+++ b/Canal/UserControls/WordInfoViews/VariableInfo.cs
@@ -1,5 +1,4 @@
-﻿using System.Drawing;
-using Model.File;
+﻿using Model.File;
 using System.Windows.Forms;
 using Util;
 
@@ -17,7 +16,7 @@ namespace Canal.UserControls.WordInfoViews
             var treeNode = FillVariableTreeView(variable);
 
             VariableInfoTreeView.SetTreeWithSelection(treeNode, _selectedNode);
-           
+
             VariableInfoTreeView.OnVariableSelected += (sender, clickedVariable) =>
             {
                 if (clickedVariable.Root != null && clickedVariable.Root.CopyReference != null)
@@ -29,7 +28,6 @@ namespace Canal.UserControls.WordInfoViews
         {
             VariableInfoTreeView.ScrollToSelectedNode();
         }
-
 
         private TreeNode FillVariableTreeView(Variable variable)
         {
@@ -56,10 +54,10 @@ namespace Canal.UserControls.WordInfoViews
                     newNode.Nodes.Add(sibling == variable
                         ? temp
                         : new TreeNode(sibling.GetLevelAndName()) { Tag = sibling });
-                    
-                        
+
+
                 }
-                
+
                 // go further up, add grandparents etc.
                 while (parent.ParentVariable != null)
                 {
@@ -71,7 +69,7 @@ namespace Canal.UserControls.WordInfoViews
                     parent = parent.ParentVariable;
                 }
             }
-         
+
             return newNode;
         }
 

--- a/Canal/UserControls/WordInfoViews/VariableInfo.cs
+++ b/Canal/UserControls/WordInfoViews/VariableInfo.cs
@@ -25,10 +25,7 @@ namespace Canal.UserControls.WordInfoViews
             };
         }
 
-        public void ScrollToSelectedVariable()
-        {
-            VariableInfoTreeView.ScrollToSelectedNode();
-        }
+
 
         private TreeNode FillVariableTreeView(Variable variable)
         {

--- a/Canal/UserControls/WordInfoViews/VariableTreeView.cs
+++ b/Canal/UserControls/WordInfoViews/VariableTreeView.cs
@@ -28,12 +28,11 @@ namespace Canal.UserControls.WordInfoViews
         {
             VariableInfoTreeView.Nodes.Add(node);
             VariableInfoTreeView.ExpandAll();
-            VariableInfoTreeView.SelectedNode = selectedTreeNode;
-        }
 
-        public void ScrollToSelectedNode()
-        {
-            VariableInfoTreeView.SelectedNode.EnsureVisible();
+            selectedTreeNode.ForeColor = Color.FromArgb(255, 207, 122, 1);
+            selectedTreeNode.BackColor = Color.FromArgb(255, 255, 188, 112);
+           
+            selectedTreeNode.EnsureVisible();
         }
 
         public void SetTree(List<TreeNode> nodes)
@@ -85,7 +84,7 @@ namespace Canal.UserControls.WordInfoViews
                                   font,
                                   new Rectangle(e.Bounds.X + LevelWidth, e.Bounds.Y, nameWidth, e.Bounds.Height),
                                   (e.State & TreeNodeStates.Selected) != 0 ? SystemColors.HighlightText : e.Node.ForeColor,
-                                  Color.Empty,
+                                  e.Node.BackColor,
                                   TextFormatFlags.VerticalCenter);
 
             // PIC

--- a/Canal/UserControls/WordInfoViews/VariableTreeView.cs
+++ b/Canal/UserControls/WordInfoViews/VariableTreeView.cs
@@ -28,11 +28,15 @@ namespace Canal.UserControls.WordInfoViews
         {
             VariableInfoTreeView.Nodes.Add(node);
             VariableInfoTreeView.ExpandAll();
-
-            selectedTreeNode.ForeColor = Color.FromArgb(255, 207, 122, 1);
+            VariableInfoTreeView.SelectedNode = selectedTreeNode;
+            selectedTreeNode.ForeColor = Color.FromArgb(255, 207, 100, 1);
             selectedTreeNode.BackColor = Color.FromArgb(255, 255, 188, 112);
-           
-            selectedTreeNode.EnsureVisible();
+        }
+
+
+        public void ScrollToSelectedNode()
+        {
+            VariableInfoTreeView.SelectedNode.EnsureVisible();
         }
 
         public void SetTree(List<TreeNode> nodes)


### PR DESCRIPTION
…ntly after doubleclicking it, the variable is now highlighted by colorsettings instead of giving focus to the tree. However, the view is not scrolling correctly to the variable if it is out of the visible part of the loaded tree but if that is the case some scroll actions can actually be noticed, I guess this comes from some bigger container/layout settings problems and will be fixed when fixing the resize behaviour of the variable tree.